### PR TITLE
fix(@pkg-tools/pkg-tools): make the monolith package's re-export of CLIs portable

### DIFF
--- a/.changeset/many-badgers-change.md
+++ b/.changeset/many-badgers-change.md
@@ -1,0 +1,10 @@
+---
+"@pkg-tools/pkg-tools": minor
+"@pkg-tools/format": minor
+"@pkg-tools/build": minor
+"@pkg-tools/clean": minor
+"@pkg-tools/lint": minor
+"@pkg-tools/sync": minor
+---
+
+Make the monolith package's re-export of the CLIs portable by adding a ./cli export to the package.json exports of all the CLI packages.

--- a/packages/@pkg-tools/build/build.config.ts
+++ b/packages/@pkg-tools/build/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig([
   {
+    failOnWarn: false,
     entries: ["src/index"],
     rollup: {
       inlineDependencies: true,
@@ -14,6 +15,7 @@ export default defineBuildConfig([
     declaration: "node16",
   },
   {
+    failOnWarn: false,
     entries: ["src/cli"],
     rollup: {
       inlineDependencies: true,

--- a/packages/@pkg-tools/build/package.json
+++ b/packages/@pkg-tools/build/package.json
@@ -12,13 +12,20 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
-    "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+    "./cli": {
+      "import": {
+        "default": "./dist/cli.mjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/@pkg-tools/clean/build.config.ts
+++ b/packages/@pkg-tools/clean/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from 'unbuild';
 
 export default defineBuildConfig([
   {
+    failOnWarn: false,
     entries: ['src/index'],
     rollup: {
       inlineDependencies: true,
@@ -14,6 +15,7 @@ export default defineBuildConfig([
     declaration: 'node16',
   },
   {
+    failOnWarn: false,
     entries: ['src/cli'],
     rollup: {
       inlineDependencies: true,

--- a/packages/@pkg-tools/clean/package.json
+++ b/packages/@pkg-tools/clean/package.json
@@ -12,13 +12,20 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
-    "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+    "./cli": {
+      "import": {
+        "default": "./dist/cli.mjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/@pkg-tools/format/build.config.ts
+++ b/packages/@pkg-tools/format/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from 'unbuild';
 
 export default defineBuildConfig([
   {
+    failOnWarn: false,
     entries: ['src/index'],
     rollup: {
       inlineDependencies: true,
@@ -14,6 +15,7 @@ export default defineBuildConfig([
     declaration: 'node16',
   },
   {
+    failOnWarn: false,
     entries: ['src/cli'],
     rollup: {
       inlineDependencies: true,

--- a/packages/@pkg-tools/format/package.json
+++ b/packages/@pkg-tools/format/package.json
@@ -12,13 +12,20 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
-    "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+    "./cli": {
+      "import": {
+        "default": "./dist/cli.mjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/@pkg-tools/lint/build.config.ts
+++ b/packages/@pkg-tools/lint/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from 'unbuild';
 
 export default defineBuildConfig([
   {
+    failOnWarn: false,
     entries: ['src/index'],
     rollup: {
       inlineDependencies: true,
@@ -14,6 +15,7 @@ export default defineBuildConfig([
     declaration: 'node16',
   },
   {
+    failOnWarn: false,
     entries: ['src/cli'],
     rollup: {
       inlineDependencies: true,

--- a/packages/@pkg-tools/lint/package.json
+++ b/packages/@pkg-tools/lint/package.json
@@ -12,13 +12,20 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
-    "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+    "./cli": {
+      "import": {
+        "default": "./dist/cli.mjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/@pkg-tools/pkg-tools/build.js
+++ b/packages/@pkg-tools/pkg-tools/build.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '@pkg-tools/build/cli';

--- a/packages/@pkg-tools/pkg-tools/clean.js
+++ b/packages/@pkg-tools/pkg-tools/clean.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '@pkg-tools/clean/cli';

--- a/packages/@pkg-tools/pkg-tools/format.js
+++ b/packages/@pkg-tools/pkg-tools/format.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '@pkg-tools/format/cli';

--- a/packages/@pkg-tools/pkg-tools/lint.js
+++ b/packages/@pkg-tools/pkg-tools/lint.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '@pkg-tools/lint/cli';

--- a/packages/@pkg-tools/pkg-tools/package.json
+++ b/packages/@pkg-tools/pkg-tools/package.json
@@ -25,12 +25,16 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "bin": {
-    "build": "./node_modules/.bin/build",
-    "clean": "./node_modules/.bin/clean",
-    "format": "./node_modules/.bin/format",
-    "lint": "./node_modules/.bin/lint"
+    "build": "./build.js",
+    "clean": "./clean.js",
+    "format": "./format.js",
+    "lint": "./lint.js"
   },
   "files": [
+    "build.js",
+    "clean.js",
+    "format.js",
+    "lint.js",
     "dist"
   ],
   "scripts": {

--- a/packages/@pkg-tools/sync/build.config.ts
+++ b/packages/@pkg-tools/sync/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig([
   {
+    failOnWarn: false,
     entries: ["src/index"],
     rollup: {
       inlineDependencies: true,
@@ -14,6 +15,7 @@ export default defineBuildConfig([
     declaration: "node16",
   },
   {
+    failOnWarn: false,
     entries: ["src/cli"],
     rollup: {
       inlineDependencies: true,

--- a/packages/@pkg-tools/sync/package.json
+++ b/packages/@pkg-tools/sync/package.json
@@ -12,13 +12,20 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
-    "require": {
-      "types": "./dist/index.d.cts",
-      "default": "./dist/index.cjs"
+    "./cli": {
+      "import": {
+        "default": "./dist/cli.mjs"
+      }
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
\+ add a `./cli` export to the package.json exports of all the CLI packages